### PR TITLE
Maximum Average Time Threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ be stores in the "reports" directory. The plugin will also check for KOed reques
 
 
     apply plugin: 'gatling'
-    
+
     gatling {
         checkForKOs = true
         koThreshold = 0
-    
+
         metrics {
             graphiteUrl = "http://my.graphite.server.com"
             metricPrefix = 'my-namespace'
         }
     }
-    
+
     import com.commercehub.gradle.plugin.GatlingTask
     task loadTest(type: GatlingTask, dependsOn: ['testClasses']) {
         gatlingSimulation = 'MyGatlingTest'
@@ -102,8 +102,11 @@ level to provide global defaults.
 
 * `graphiteUrl` : The graphite base url.
 * `graphiteMetricPrefix` : prefix to add to the graphite metric.
-* `metricsToCheck` : The list of graphite metrics to check. Metrics in this list will be pre-pended with. 
+* `metricsToCheck` : The list of graphite metrics to check. Metrics in this list will be pre-pended with.
  `gatling.<graphiteMetricPrefix>.<gatlingSimulation(lowercase)>`.
+* `thresholdsByMetricIndex` : The list of timing thresholds(in ms) that you don't want your average test times exceed.
+ Must be a positive integer. Must have one threshold per 'metricsToCheck' or exclude from configuration to bypass tests.
+ The index of the threshold number correlates to the index of the metric in 'metricsToCheck' that it belongs to.
 * `numberOfDaysToCheck` : Number of previous days to compare the current run to. If this value is 0, no check will occur.
  Must be a positive integer. Defaults to 0.
 * `degradationTolerance` : Percentage threshold for which the current average response times for a metric cannot exceed

--- a/src/main/groovy/com/commercehub/gradle/plugin/GatlingTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/plugin/GatlingTask.groovy
@@ -131,7 +131,7 @@ class GatlingTask extends DefaultTask {
             }
             if (hasThresholds) {
                 try {
-                    MetricChecker.checkMinimumThresholdTolerance(metrics.graphiteUrl, metrics.metricPrefix, gatlingSimulation,
+                    MetricChecker.checkMaximumThresholdTolerance(metrics.graphiteUrl, metrics.metricPrefix, gatlingSimulation,
                             metricName, metrics.thresholdsByMetricIndex[metricIndex])
                 } catch (GatlingGradlePluginException e) {
                     handleFailure("FAILED Metric Check ($metricName)", e)

--- a/src/main/groovy/com/commercehub/gradle/plugin/MetricChecker.groovy
+++ b/src/main/groovy/com/commercehub/gradle/plugin/MetricChecker.groovy
@@ -71,17 +71,17 @@ class MetricChecker {
     }
 
     /**
-     * Verify that the current mean response time for the given metric is not over a given minimum threshold
+     * Verify that the current mean response time for the given metric is not over a given maximum threshold
      * specfied by the test.
      *
      * @param baseUrl base graphite url
      * @param scenario the scenario to check
      * @param metricName the metric to check (case sensitive with underscores instead of spaces ie 'Get_by_Organization_id')
-     * @param minimumPerformanceThreshold the minimum amount of time(ms) you expect this test to run
+     * @param maximumPerformanceThreshold the maximum amount of time(ms) you expect this test to run
      */
 
-    static void checkMinimumThresholdTolerance(String baseUrl, String graphitePrefix, String scenario,
-                                               String metricName, Number minimumPerformanceThreshold) {
+    static void checkMaximumThresholdTolerance(String baseUrl, String graphitePrefix, String scenario,
+                                               String metricName, Number maximumPerformanceThreshold) {
         String apiPrefix = '/render/?target='
         String metric = buildMetricPath(graphitePrefix, scenario, metricName)
         String format = "&format=json"
@@ -102,10 +102,10 @@ class MetricChecker {
 
                 // Get the most recent response time
                 def currentResponseTime = meanTimes.last()
-                if (currentResponseTime > minimumPerformanceThreshold) {
+                if (currentResponseTime > maximumPerformanceThreshold) {
                     throw new GatlingGradlePluginException(
                             "Current response time ${currentResponseTime} exceeds the tolerance for minimum " +
-                                    "performance threshold (${minimumPerformanceThreshold}) for ${metricName}.\n")
+                                    "performance threshold (${maximumPerformanceThreshold}) for ${metricName}.\n")
                 }
             }
         }

--- a/src/main/groovy/com/commercehub/gradle/plugin/MetricChecker.groovy
+++ b/src/main/groovy/com/commercehub/gradle/plugin/MetricChecker.groovy
@@ -27,7 +27,7 @@ class MetricChecker {
      */
     static void checkPreviousDays(String baseUrl, String graphitePrefix, String scenario,
                                   String metricName, int numberOfDays, Number degradationTolerance) {
-        final long DAYS_IN_MS = 1000 * 60 * 60 * 24
+        final long DAYS_IN_MS = numberOfDays * 1000 * 60 * 60 * 24
         final Date START_DATE = new Date(System.currentTimeMillis() - DAYS_IN_MS).clearTime()
 
         String apiPrefix = '/render/?target='


### PR DESCRIPTION
Currently with how the gatling plugin behaves, we can only check to see if there is a certain percentage of degradation in performance based on runs over the past 'X' days. This leaves us open for the chance of a large time degradation over an extended period of time going undetected. This change allows users to define a hard maximum in Milliseconds for each metric they check. If this metric's average time goes above the defined threshold, we consider that the run has degraded past acceptable levels and fail the build.